### PR TITLE
Updating docs with cloud compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ The recommended way of setting your local data directory is to set the `SPEDAS_D
 
 Mission specific data directories (e.g., `MMS_DATA_DIR` for MMS, `THM_DATA_DIR` for THEMIS) can also be set, and these will override `SPEDAS_DATA_DIR`
 
+## Cloud Repositories
+
+`SPEDAS_DATA_DIR` and mission specific data directories can also be the URI of a cloud repository (e.g., an S3 repository). If this data directory is set to an URI, files will be downloaded from the data server to the URI location. The data will then be streamed from the URI without needing to download the file locally. 
+
+In order to successfully access the specified cloud repository, the user is required to correctly set up permissions to be able to read and write to that cloud repository on their own. Refer (here)[https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html] for how to prepare your AWS configuration and credentials.
 
 ## Usage
 
@@ -157,7 +162,7 @@ stereo_files = pyspedas.stereo.mag(trange=['2013-11-1', '2013-11-6'], downloadon
 - `varformat`: string specifying which CDF variables to load; accepts the wild cards * and ?
 - `varnames`: string specifying which CDF variables to load (exact names)
 - `get_support_data`: if set, load the support variables from the CDFs
-- `downloadonly`: if set, download the files but do not load them into tplot
+- `downloadonly`: if set, download the files but do not load them into tplot.
 - `no_update`: if set, only load the data from the local cache
 - `notplot`: if set, load the variables into dictionaries containing numpy arrays (instead of creating the tplot variables)
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ stereo_files = pyspedas.stereo.mag(trange=['2013-11-1', '2013-11-6'], downloadon
 - `varformat`: string specifying which CDF variables to load; accepts the wild cards * and ?
 - `varnames`: string specifying which CDF variables to load (exact names)
 - `get_support_data`: if set, load the support variables from the CDFs
-- `downloadonly`: if set, download the files but do not load them into tplot.
+- `downloadonly`: if set, download the files but do not load them into tplot
 - `no_update`: if set, only load the data from the local cache
 - `notplot`: if set, load the variables into dictionaries containing numpy arrays (instead of creating the tplot variables)
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -35,7 +35,7 @@ Cloud Repositories
 ------------------------
 **SPEDAS_DATA_DIR** and mission specific data directories can also be the URI of a cloud repository (e.g., an S3 repository). If this data directory is set to an URI, files will be downloaded from the data server to the URI location. The data will then be streamed from the URI without needing to download the file locally. 
 
-In order to successfully access the specified cloud repository, the user is required to correctly set up access permissions to that cloud repository on their own. Refer `here <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html>`_ for how to prepare your AWS configuration and credentials.
+In order to successfully access the specified cloud repository, the user is required to correctly set up permissions to be able to read and write to that cloud repository on their own. Refer `here <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html>`_ for how to prepare your AWS configuration and credentials.
 
 Loading and Plotting Data
 ---------------------------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -33,7 +33,7 @@ Mission specific data directories (e.g., **MMS_DATA_DIR** for MMS, **THM_DATA_DI
 
 Cloud Repositories
 ------------------------
-**SPEDAS_DATA_DIR** and mission specific data directories can also be the URI of a cloud repository (e.g., an S3 repository). If this data directory is set to an URI, files will be downloaded to the URI location. The data will then be streamed from the URI without needing to download the file locally. 
+**SPEDAS_DATA_DIR** and mission specific data directories can also be the URI of a cloud repository (e.g., an S3 repository). If this data directory is set to an URI, files will be downloaded from the data server to the URI location. The data will then be streamed from the URI without needing to download the file locally. 
 
 In order to successfully access the specified cloud repository, the user is required to correctly set up permissions on their own. Refer `here <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html>`_ for how to prepare your AWS configuration and credentials.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -35,7 +35,7 @@ Cloud Repositories
 ------------------------
 **SPEDAS_DATA_DIR** and mission specific data directories can also be the URI of a cloud repository (e.g., an S3 repository). If this data directory is set to an URI, files will be downloaded from the data server to the URI location. The data will then be streamed from the URI without needing to download the file locally. 
 
-In order to successfully access the specified cloud repository, the user is required to correctly set up permissions on their own. Refer `here <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html>`_ for how to prepare your AWS configuration and credentials.
+In order to successfully access the specified cloud repository, the user is required to correctly set up access permissions to that cloud repository on their own. Refer `here <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html>`_ for how to prepare your AWS configuration and credentials.
 
 Loading and Plotting Data
 ---------------------------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -31,6 +31,12 @@ By default, the data is stored in your pyspedas directory in a folder named 'pyd
 
 Mission specific data directories (e.g., **MMS_DATA_DIR** for MMS, **THM_DATA_DIR** for THEMIS) can also be set, and these will override **SPEDAS_DATA_DIR**.
 
+Cloud Repositories
+------------------------
+**SPEDAS_DATA_DIR** and mission specific data directories can also be the URI of a cloud repository (e.g., an S3 repository). If this data directory is set to an URI, files will be downloaded to the URI location. The data will then be streamed from the URI without needing to download the file locally. 
+
+In order to successfully access the specified cloud repository, the user is required to correctly set up permissions on their own. Refer `here <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html>`_ for how to prepare your AWS configuration and credentials.
+
 Loading and Plotting Data
 ---------------------------
 You can load data into tplot variables by calling pyspedas.mission.instrument(), e.g.,

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -8,7 +8,8 @@ Some key points that apply to most or all of these load routines:
 
 * PySPEDAS maintains a cache of previously downloaded data.   The cache location to use is controlled by the SPEDAS_DATA_DIR environment variable.
   Many missions allow the user to set a data directory specific to that mission, overriding the global SPEDAS_DATA_DIR setting. For example,
-  THM_DATA_DIR can be used to specify the local directory to use for the THEMIS mission.
+  THM_DATA_DIR can be used to specify the local directory to use for the THEMIS mission. 
+  The cache location can be a local file directory or a URI location (e.g., an S3 repository).
 
 * By default, PySPEDAS contacts the data server to get a list of filenames to fulfill the request,
   and compares the modification times on the server and locally cached files to determine


### PR DESCRIPTION
Added documentation on use of URI for `SPEDAS_DATA_DIR`.

I added that there is now the ability to read from URIs in these docs:
- Getting started landing page: `docs/source/getting_started.rst`
- Projects landing page: `docs/source/projects.rst`
- PySPEDAS readme: `README.md`

It mostly focuses on reading from a data server (SPDF) to an s3 location. I think most of the keyword functionality stays the same even if `SPEDAS_DATA_DIR` is an URI instead of a local directory, so I let most of the verbiage stay the same. Let me know if you think there is something important to document in the keyword descriptions that I've missed.

One thing we should add later is a link to an example notebook of how to set, use and access a `SPEDAS_DATA_DIR` when it is an s3 URI. That notebook will go into the `pyspedas_examples` repo, but we should have a link to it in the "Examples" section of `README.md`